### PR TITLE
Fix uv sync command in deploy-backend.yml

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -51,7 +51,7 @@ jobs:
             - name: Install uv and dependencies
               run: |
                   pip install uv
-                  uv sync --system --no-cache
+                  uv sync --no-cache
               working-directory: ${{ env.WORKING_DIRECTORY }}
 
             # --- Step 4: Azure App Serviceへのデプロイ ---


### PR DESCRIPTION
Remove the unnecessary `--system` flag from the `uv sync` command to ensure proper synchronization during deployment.