### PR TITLE
Enable workspace package injection in pnpm lockfile settings

### DIFF
--- a/LV3/frontend/pnpm-lock.yaml
+++ b/LV3/frontend/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+  injectWorkspacePackages: true
 
 importers:
 


### PR DESCRIPTION
Enable the injection of workspace packages in the pnpm lockfile settings to improve package management.