### PR TITLE
Comment out hoist setting in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 # inject-workspace-packages = true
 # shamefully-hoist = true
-node-linker = hoisted
+# node-linker = hoisted


### PR DESCRIPTION
Comment out the `shamefully-hoist` setting in the `.npmrc` file to adjust package linking behavior.