### PR TITLE
Rename .npmrc and configure package hoisting for deployment

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -56,7 +56,9 @@ jobs:
 
       # --- Step 4: 依存関係のインストール ---
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          cp .npmrc.prod .npmrc
+          npm install --frozen-lockfile
 
       # --- Step 5: Next.jsアプリケーションのビルド ---
       - name: Build Next.js app

--- a/.npmrc.prod
+++ b/.npmrc.prod
@@ -1,3 +1,3 @@
 # inject-workspace-packages = true
 # shamefully-hoist = true
-# node-linker = hoisted
+node-linker = hoisted


### PR DESCRIPTION
Rename the .npmrc file and adjust the configuration to hoist packages only during deployment, ensuring a smoother installation process.