### PR TITLE
Add git.ignoreLimitWarning setting in VSCode configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "github-actions.workflows.pinned.workflows": [
         ".github/workflows/deploy-backend.yml",
         ".github/workflows/deploy-frontend.yml"
-    ]
+    ],
+    "git.ignoreLimitWarning": true
 }


### PR DESCRIPTION
Introduce a new setting to suppress the limit warning for Git operations in VSCode.